### PR TITLE
Update cesm2-le catalog

### DIFF
--- a/catalogs/glade-cesm2-le.json
+++ b/catalogs/glade-cesm2-le.json
@@ -73,11 +73,11 @@
   "aggregation_control": {
     "variable_column_name": "variable",
     "groupby_attrs": [
-      "experiment",
       "component",
-      "control_branch_year",
-      "forcing_variant",
+      "experiment",
       "stream",
+      "forcing_variant",
+      "control_branch_year",
       "variable"
     ],
     "aggregations": [
@@ -93,15 +93,12 @@
       {
         "type": "join_new",
         "attribute_name": "member_id",
-        "options": {
-          "coords": "minimal",
-          "compat": "override"
-        }
-       }
+        "options": { "coords": "minimal", "compat": "override" }
+      }
      ]
   },
   "esmcat_version": "0.0.1",
-  "id": "glade-cesm2-le",
-  "description": "ESM collection for the CESM2 LENS data stored on GLADE in /glade/campaign/cgd/cesm/CESM2-LE/timeseries",
+  "id": null,
+  "description": null,
   "last_updated": "2021-06-17T02:58:33+00:00"
 }

--- a/catalogs/glade-cesm2-le.json
+++ b/catalogs/glade-cesm2-le.json
@@ -98,7 +98,7 @@
      ]
   },
   "esmcat_version": "0.0.1",
-  "id": null,
-  "description": null,
+  "id": "glade-cesm2-le",
+  "description": "ESM collection for the CESM2 LENS data stored on GLADE in /glade/campaign/cgd/cesm/CESM2-LE/timeseries",
   "last_updated": "2021-06-17T02:58:33+00:00"
 }


### PR DESCRIPTION
Update the groupby dimensions for the `cesm2-le` catalog - this now matches the way we are building the zarr stores for AWS