### PR TITLE
Fix to _pick_latest_version

### DIFF
--- a/builders/cmip.py
+++ b/builders/cmip.py
@@ -103,7 +103,7 @@ def _pick_latest_version(df):
     import itertools
 
     print(f'Dataframe size before picking latest version: {len(df)}')
-    grpby = list(set(df.columns.tolist()) - {'path', 'version', 'dcpp_init_year'})
+    grpby = list(set(df.columns.tolist()) - {'path', 'version', 'dcpp_init_year', 'time_range'})
     grouped = df.groupby(grpby)
 
     def _pick_latest_v(group):


### PR DESCRIPTION
I have used this package to build catalog files for CMIP6 data stored on the Princeton HPC filesystem. I recently ran into a situation where building the catalog seemingly does not remove older versions. An example:
```python
col.search(source_id='ACCESS-ESM1-5', experiment_id='ssp585', member_id='r1i1p1f1', grid_label='gn', table_id='Ofx', variable_id='areacello').df
```
results in 
![image](https://user-images.githubusercontent.com/14314623/132389654-cc7615cb-1b8e-47b4-83d1-5dcd9e2562cc.png)

I believe the issue here is the `Nan` in the `time_range` field. If I manually add `time_range` as in this PR I get the expected output:
![image](https://user-images.githubusercontent.com/14314623/132389862-a8cccb8b-d769-4bf6-9a3a-4446d15f59cd.png)

Do you think this can be added without a loss of functionality for other projects?