### PR TITLE
Update CESM2-LE catalog December

### DIFF
--- a/catalogs/glade-cesm2-le.json
+++ b/catalogs/glade-cesm2-le.json
@@ -115,5 +115,5 @@
   "esmcat_version": "0.0.1",
   "id": "glade-cesm2-le",
   "description": "ESM collection for the CESM2 LENS data stored on GLADE in /glade/campaign/cgd/cesm/CESM2-LE/timeseries",
-  "last_updated": "2021-10-12T14:25:10+00:00"
+  "last_updated": "2021-12-02T14:25:10+00:00"
 }


### PR DESCRIPTION
I reran the catalog builder, verifying that the data Steve mentioned is missing (ex. `1231.002:186001-186912`) is cataloged properly.