### PR TITLE
Enable to use `build_cmip` for projects with similar data standard...

### DIFF
--- a/builders/cmip.py
+++ b/builders/cmip.py
@@ -168,7 +168,7 @@ def build_cmip(
     b = Builder(columns, exclude_patterns)
     df = b(filelist, parsers[cmip_version])
 
-    if cmip_version == '6':
+    if cmip_version == '6' and "activity_id" in columns:
         # Some entries are invalid: Don't conform to the CMIP6 Data Reference Syntax
         cmip6_activity_id_url = (
             'https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_activity_id.json'


### PR DESCRIPTION
... but different column names.

I.e., stop checking against `activity_id` if not present in `columns`.